### PR TITLE
fixed #23

### DIFF
--- a/src/components/AudienceItem.css
+++ b/src/components/AudienceItem.css
@@ -16,6 +16,11 @@
 }
 
 .audience-item__video {
+  width: 0;
+  height: 0;
+}
+
+.audience-item__icon {
   pointer-events: none;
   clip-path: circle(36%);
   width: 13vw;

--- a/src/components/AudienceItem.tsx
+++ b/src/components/AudienceItem.tsx
@@ -52,8 +52,7 @@ class AudienceItem extends React.PureComponent<IProps> {
   }
 
   render() {
-    const { isMuted, isSelected } = this.props;
-
+    const { isSelected, isMuted, audience } = this.props;
     return (
       <li
         className={
@@ -61,6 +60,7 @@ class AudienceItem extends React.PureComponent<IProps> {
         }
         onClick={this._onClick}
       >
+        <img src={audience.dataURL} className="audience-item__icon"></img>
         <video
           className="audience-item__video"
           muted={isMuted}

--- a/src/components/Participation.css
+++ b/src/components/Participation.css
@@ -1,10 +1,23 @@
 .participation {
   display: flex;
   align-items: center;
+  flex-direction: column;
   justify-content: center;
   width: 100%;
   height: 100%;
   background-color: #f9f9fa;
+}
+
+.participation__capture {
+  clip-path: circle(36%);
+  width: 30vw;
+  height: 30vw;
+  background-color: #4e6fa3;
+}
+
+.participation__video {
+  width: 100%;
+  height: 100%;
 }
 
 .participation__button {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,8 @@ export interface Map {
 
 export interface Member {
   peerId: string;
-  stream: any;
+  stream?: any;
+  dataURL?: string;
 }
 
 export interface Pointing {


### PR DESCRIPTION
まだ全然できてないです…すいません！

今はparticipate(最初の画面)で静止画を取得してdataURLにしてactionに送り,actionでlocalpeer.idとセットにしてreducerに送り,reducerで上記の二つの値をIcon型（typesで設定しました）としてstoreに送ります.
そしてそのstoreのIcon型の値をAudienceItemで参照することでアイコンを静止画にします.

今の問題としては,
1. actionのparticipateからroomにsendできないこと
2.送れたとしても,localpeer.idで区別したdataURLをそれぞれ保持できないのではないかということ
　（storeを更新する感じだと最後に入室した一人分のデータしか保持できない？）

この二つの点について相談させて頂きたいです！
よろしくお願いします.