### PR TITLE
fixed #24

### DIFF
--- a/src/components/Participation.css
+++ b/src/components/Participation.css
@@ -13,11 +13,14 @@
   width: 30vw;
   height: 30vw;
   background-color: #4e6fa3;
+  transform: translate(7vw, -3vw);
 }
 
 .participation__video {
+  clip-path: circle(37%);
   width: 100%;
   height: 100%;
+  transform: scale(0.9);
 }
 
 .participation__button {
@@ -42,4 +45,15 @@
   color: #d70022;
   font-size: 3vw;
   font-weight: 100;
+  padding-top: 1.2vw;
+  padding-bottom: 1.2vw;
+}
+
+.participation__pointing-image {
+  transform: rotate(-90deg) translate(7.5vw, -13vw);
+  position: absolute;
+  background-color: transparent;
+  width: 20vw;
+  height: 20vw;
+  z-index: 1;
 }

--- a/src/components/Participation.tsx
+++ b/src/components/Participation.tsx
@@ -8,6 +8,7 @@ import { TStore } from "../store";
 import { participate } from "../actions";
 import { InitializeMap } from "../actions";
 
+import logo from "./Pointing.png";
 import "./Participation.css";
 
 interface IProps {
@@ -122,6 +123,7 @@ class Participation extends React.PureComponent<IProps, IState> {
 
     return (
       <section className="participation">
+        <img className="participation__pointing-image" src={logo} />
         <div className="participation__capture">
           <video
             className="participation__video"


### PR DESCRIPTION
矢印の画像を付けたのですが、participation.tsxの画面では矢印の画像のアスペクト比がおかしくなるため、cssのtransform: scaleで調整しています…
なぜ、アスペクト比がおかしくなってしまうのでしょうか…？