### PR TITLE
fixed #29

### DIFF
--- a/src/components/MapPanel.tsx
+++ b/src/components/MapPanel.tsx
@@ -15,14 +15,15 @@ import "./MapPanel.css";
 interface IProps {
   map?: Map;
   isMapEnabled: boolean;
+  isPresenterMapEnabled: boolean;
 }
 const AnyReactComponent = ({ pinImage }: any) => {
   return <img src={pinImage} alt="current position" />;
 };
 class MapPanel extends React.PureComponent<IProps> {
   render() {
-    const { isMapEnabled, map } = this.props;
-    const className = isMapEnabled ? "mappanel" : "mappanel--disabled";
+    const { isPresenterMapEnabled, map } = this.props;
+    const className = isPresenterMapEnabled ? "mappanel" : "mappanel--disabled";
 
     if (!map) {
       return null;
@@ -50,6 +51,7 @@ class MapPanel extends React.PureComponent<IProps> {
 const mapStateToProps = (store: TStore) => {
   return {
     isMapEnabled: store.state.isMapEnabled,
+    isPresenterMapEnabled: store.state.isPresenterMapEnabled,
     map: store.state.map,
   };
 };

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -11,6 +11,7 @@ import {
   ToggleCameraMutingAction,
   ToggleMapMutingAction,
   OnMapLocationChangedAction,
+  OnMapLocationMutedAction,
   OnIconUpdatedAction,
   OnPeerSelectedAction,
   OnTransformChangedAction,
@@ -23,6 +24,7 @@ export interface IState {
   isAudioEnabled: boolean;
   isCameraEnabled: boolean;
   isMapEnabled: boolean;
+  isPresenterMapEnabled: boolean;
   localPeer?: Peer;
   localStream?: MediaStream;
   room?: SFURoom | MeshRoom;
@@ -40,6 +42,7 @@ const initialState: IState = {
   isAudioEnabled: true,
   isCameraEnabled: true,
   isMapEnabled: true,
+  isPresenterMapEnabled: false,
   pointings: [],
   transform: { x: 0, y: 0, scale: 1 },
 };
@@ -151,6 +154,9 @@ export const reducer = reducerWithInitialState(initialState)
     return Object.assign({}, state, {
       map: Object.assign({}, state.map, { lat, lng }),
     });
+  })
+  .case(OnMapLocationMutedAction, (state, { isMapEnabled }) => {
+    return Object.assign({}, state, { isPresenterMapEnabled: isMapEnabled });
   })
   .case(OnIconUpdatedAction, (state, { dataURL, peerId }) => {
     const index = state.audiences.findIndex(a => a.peerId === peerId);


### PR DESCRIPTION
修正しました！
isMapEnabled_presenterでプレゼンターのmuteを判断して、trueだったらオーディエンスのトグル処理が効くようにしてます！
(これがないと、プレゼンターがmuteにしてもオーディエンスのトグル処理でマップが表示されてしまうため)